### PR TITLE
Update combine-tailoring.py

### DIFF
--- a/combine-tailoring.py
+++ b/combine-tailoring.py
@@ -46,7 +46,7 @@ def main():
         help="XCCDF 1.2 Tailoring file to insert"
     )
     parser.add_argument(
-        "--output", type=argparse.FileType("w"), required=False,
+        "--output", type=argparse.FileType("wb"), required=False,
         default=sys.stdout,
         help="Resulting XCCDF or Source DataStream"
     )


### PR DESCRIPTION
Added binary mode option to output file. Had issues with python in Windows erroring out with "write() argument must be str, not bytes." See: https://stackoverflow.com/a/5513856/3101412